### PR TITLE
fix: checkboxの値を保持する

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3005 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/components/molecules/GenreCheckboxModal/GenreCheckboxGroup/index.tsx
+++ b/src/components/molecules/GenreCheckboxModal/GenreCheckboxGroup/index.tsx
@@ -6,8 +6,9 @@ import GenreCategory from "../../../../models/GenreCategory";
 import { CheckboxValueType } from "antd/es/checkbox/Group";
 
 type Props = {
+  defaultValues?: string[];
   genreCategory: GenreCategory;
-  checkValues: ({ values }: {values: string[]}) => void;
+  onCheckValues: ({ values }: { values: string[] }) => void;
 };
 
 interface GenreOption {
@@ -15,26 +16,30 @@ interface GenreOption {
   value: string;
 }
 
-const GenreCheckboxGroup = ({ genreCategory, checkValues }: Props) => {
-  const [checkedValues, setCheckedValues] = useState<CheckboxValueType[]>([])
+const GenreCheckboxGroup = ({ defaultValues, genreCategory, onCheckValues }: Props) => {
+  const [checkedValues, setCheckedValues] = useState<CheckboxValueType[]>(defaultValues ?? []);
   const [open, setOpen] = useState(false);
   const icon = open ? <DownOutline /> : <RightOutline />;
   const genres: GenreOption[] = [];
   const onChange = (checkedValues: CheckboxValueType[]) => {
     const values: string[] = [];
     setCheckedValues(checkedValues);
-    checkedValues.map((value) => (
-      values.push(value as string)
-    ))
+    checkedValues.map((value) => values.push(value as string));
     console.log("checkedValues");
     console.log(checkedValues);
 
-    checkValues({ values: values });
-  }
+    onCheckValues({ values: values });
+  };
 
   genreCategory.genres.map((genre) => genres.push({ label: genre.name, value: genre.id }));
 
-  const menus = open ? <div className={styles.checkbox}><Checkbox.Group defaultValue={checkedValues} onChange={onChange} options={genres}/></div> : "";
+  const menus = open ? (
+    <div className={styles.checkbox}>
+      <Checkbox.Group defaultValue={checkedValues} onChange={onChange} options={genres} />
+    </div>
+  ) : (
+    ""
+  );
 
   return (
     <div className={styles.genreCheckboxGroup}>

--- a/src/components/molecules/GenreCheckboxModal/index.tsx
+++ b/src/components/molecules/GenreCheckboxModal/index.tsx
@@ -6,19 +6,19 @@ import GenreCategory from "../../../models/GenreCategory";
 import GenreCheckboxGroup from "./GenreCheckboxGroup";
 
 type Props = {
-  collectGenreIds: ({ ids }: {ids: string[]}) => void,
-}
+  onCheck: ({ ids }: { ids: string[] }) => void;
+  isOpen: boolean;
+};
 
-const GenreCheckboxModal = ({ collectGenreIds }: Props) => {
+const GenreCheckboxModal = ({ onCheck, isOpen }: Props) => {
   const [genreCategories, setGenreCategories] = useState<GenreCategory[]>([]);
   const [checkedValues, setCheckedValues] = useState<string[]>([]);
+  console.log(checkedValues);
 
-  const checkValues = ({ values }: { values: string[] }): void => {
+  const onCheckValues = ({ values }: { values: string[] }): void => {
     setCheckedValues([...checkedValues, ...values]);
-    collectGenreIds({ ids: checkedValues});
-  }
-
-  collectGenreIds({ ids: checkedValues});
+    onCheck({ ids: checkedValues });
+  };
 
   async function fetchData() {
     const request = await axios
@@ -36,12 +36,14 @@ const GenreCheckboxModal = ({ collectGenreIds }: Props) => {
     fetchData();
   }, []);
 
-  return (
+  return isOpen ? (
     <div className={styles.genreCheckboxModal}>
       {genreCategories.map((genreCategory, idx) => (
-        <GenreCheckboxGroup key={idx} genreCategory={genreCategory} checkValues={checkValues} />
+        <GenreCheckboxGroup key={idx} defaultValues={checkedValues} genreCategory={genreCategory} onCheckValues={onCheckValues} />
       ))}
     </div>
+  ) : (
+    <div />
   );
 };
 

--- a/src/components/pages/TopPage/Top/index.tsx
+++ b/src/components/pages/TopPage/Top/index.tsx
@@ -32,11 +32,10 @@ const Top = () => {
   const closeSideDrawer = (): void => {
     setOpenGenreModal(false);
   };
-  const collectGenreIds = ({ ids }: {ids: string[]}): void => {
+  const collectGenreIds = ({ ids }: { ids: string[] }): void => {
     setGenreIds(ids);
-  }
+  };
 
-  const genreModal = openGenreModal ? <GenreCheckboxModal collectGenreIds={collectGenreIds}/> : "";
   const backdrop = openGenreModal ? <BackDrop closeSideDrawer={closeSideDrawer} /> : "";
 
   const [keyword, setKeyword] = useState<string>();
@@ -105,10 +104,6 @@ const Top = () => {
     fetchData();
   }, []);
 
-  console.log(keyword);
-  console.log(genreIds);
-  console.log(sortBy);
-
   return (
     <div>
       {/*<form className={styles.form} onSubmit={handleSubmit(onSubmit)}>*/}
@@ -121,13 +116,15 @@ const Top = () => {
       {/*</form>*/}
       <div className={styles.form}>
         <input className={styles.searchBar} onChange={(e) => setKeyword(e.target.value)} value={keyword} type="text" placeholder="キーワード" />
-        <div className={styles.genreInput} onClick={() => setOpenGenreModal(true)}><p>ジャンル</p></div>
-        <Select className={styles.sortByInput} onChange={(e) => e !== null ? setSortBy(e.value) : null} defaultValue={defaultSortByParams} options={SortByObjects} />
+        <div className={styles.genreInput} onClick={() => setOpenGenreModal(true)}>
+          <p>ジャンル</p>
+        </div>
+        <Select className={styles.sortByInput} onChange={(e) => (e !== null ? setSortBy(e.value) : null)} defaultValue={defaultSortByParams} options={SortByObjects} />
         <Button className={styles.searchButton} onClick={() => onSubmit()}>
           検索
         </Button>
       </div>
-      {genreModal}
+      <GenreCheckboxModal onCheck={collectGenreIds} isOpen={openGenreModal} />
       {backdrop}
       <div className={styles.rankingsCount}>
         <ContentOutline /> {rankingsCount}


### PR DESCRIPTION
原因としてはGenreCheckboxModalがopenGenreModalがfalseの時にjsxから消える(unmountされる)ので、再度openGenreModalがtrueになってGenreCheckboxModalがmountされた時に
`  const [checkedValues, setCheckedValues] = useState<CheckboxValueType[]>( []);`の値が初期化されるからです。
また、checkedValuesの値がGenreCheckboxGroupコンポーネントに渡されていないので、checkedValuesに値が入っていてもcheckboxはcheckされないので、defaultValueを渡せるようにしました